### PR TITLE
CxSCA-Remediation

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
   },
   "dependencies": {
     "accepts": "1.3.5",
-    "adm-zip": "0.4.7",
-    "lodash": "4.17.11",
-    "commander": "2.19.0",
-    "qs": "6.2.1"
+    "adm-zip": "0.4.11",
+    "lodash": "4.17.12",
+    "commander": "2.20.1",
+    "qs": "6.2.3"
   },
   "description": "Command line argument parser",
   "devDependencies": {},


### PR DESCRIPTION
### Packages updated by CxSCA-Remediation

**package.json:**
 - adm-zip: 0.4.7 🠚 0.4.11 (Fixes: CVE-2018-1002204)
 - commander: 2.19.0 🠚 2.20.1 (Fixes: Cx435a6fda-ca38)
 - lodash: 4.17.11 🠚 4.17.12 (Fixes: CVE-2019-10744)
 - qs: 6.2.1 🠚 6.2.3 (Fixes: CVE-2017-1000048)
