### PR TITLE
CxSCA-Remediation

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/lahmatiy/clap/issues"
   },
   "dependencies": {
-    "adm-zip": "0.4.7"
+    "adm-zip": "0.4.11"
   },
   "description": "Command line argument parser",
   "devDependencies": {},


### PR DESCRIPTION
### Packages updated by CxSCA-Remediation

**package.json:**
 - adm-zip: 0.4.7 🠚 0.4.11 (Fixes: CVE-2018-1002204)
